### PR TITLE
ci: add artifact verification and simplify release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,23 +108,23 @@ jobs:
       - name: Verify macOS amd64 binary
         run: |
           chmod +x ./dist/terranova-*-darwin-amd64
-          ./dist/terranova-*-darwin-amd64 || exit 1
+          ./dist/terranova-*-darwin-amd64 --version || exit 1
         if: runner.arch == 'X64' && runner.os == 'macOS'
 
       - name: Verify macOS arm64 binary
         run: |
           chmod +x ./dist/terranova-*-darwin-arm64
-          ./dist/terranova-*-darwin-arm64 || exit 1
+          ./dist/terranova-*-darwin-arm64 --version || exit 1
         if: runner.arch == 'ARM64' && runner.os == 'macOS'
 
       - name: Verify linux amd64 binary
         run: |
           chmod +x ./dist/terranova-*-linux-amd64
-          ./dist/terranova-*-linux-amd64 || exit 1
+          ./dist/terranova-*-linux-amd64 --version || exit 1
         if: runner.arch == 'X64' && runner.os == 'Linux'
 
       - name: Verify linux arm64 binary
         run: |
           chmod +x ./dist/terranova-*-linux-arm64
-          ./dist/terranova-*-linux-arm64 || exit 1
+          ./dist/terranova-*-linux-arm64 --version || exit 1
         if: runner.arch == 'ARM64' && runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
   build:
     permissions:
       id-token: write
+      attestations: write
+      artifact-metadata: write
     needs:
       - lint
     strategy:
@@ -93,7 +95,7 @@ jobs:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
 
       - name: Install environment
         uses: ./.github/workflows/env-install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         run: uv run poe lint
 
   build:
+    permissions:
+      id-token: write
     needs:
       - lint
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,15 @@ jobs:
       - name: Build
         run: uv run poe build
 
+      - uses: actions/attest@v4
+        with:
+          subject-path: "dist/*"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: terranova-${{ matrix.os }}
+          path: "dist/*"
+
   test:
     needs:
       - build
@@ -70,3 +79,43 @@ jobs:
 
       - name: Test
         run: uv run poe test
+
+  sanitize:
+    needs:
+      - test
+    strategy:
+      matrix:
+        os:
+          - macos-15
+          - macos-15-intel
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install environment
+        uses: ./.github/workflows/env-install
+
+      - uses: actions/download-artifact@v8
+        with:
+          merge-multiple: true
+
+      - name: Verify macOS amd64 binary
+        run: |
+          ./dist/terranova-*-darwin-amd64 || exit 1
+        if: runner.arch == 'X64' && runner.os == 'macOS'
+
+      - name: Verify macOS arm64 binary
+        run: |
+          ./dist/terranova-*-darwin-arm64 || exit 1
+        if: runner.arch == 'ARM64' && runner.os == 'macOS'
+
+      - name: Verify linux amd64 binary
+        run: |
+          ./dist/terranova-*-linux-amd64 || exit 1
+        if: runner.arch == 'X64' && runner.os == 'Linux'
+
+      - name: Verify linux arm64 binary
+        run: |
+          ./dist/terranova-*-linux-arm64 || exit 1
+        if: runner.arch == 'ARM64' && runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           merge-multiple: true
+          path: dist
 
       - name: Verify macOS amd64 binary
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,20 +107,24 @@ jobs:
 
       - name: Verify macOS amd64 binary
         run: |
+          chmod +x ./dist/terranova-*-darwin-amd64
           ./dist/terranova-*-darwin-amd64 || exit 1
         if: runner.arch == 'X64' && runner.os == 'macOS'
 
       - name: Verify macOS arm64 binary
         run: |
+          chmod +x ./dist/terranova-*-darwin-arm64
           ./dist/terranova-*-darwin-arm64 || exit 1
         if: runner.arch == 'ARM64' && runner.os == 'macOS'
 
       - name: Verify linux amd64 binary
         run: |
+          chmod +x ./dist/terranova-*-linux-amd64
           ./dist/terranova-*-linux-amd64 || exit 1
         if: runner.arch == 'X64' && runner.os == 'Linux'
 
       - name: Verify linux arm64 binary
         run: |
+          chmod +x ./dist/terranova-*-linux-arm64
           ./dist/terranova-*-linux-arm64 || exit 1
         if: runner.arch == 'ARM64' && runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,36 +19,12 @@ concurrency:
   group: ${{ github.workflow }}
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        os:
-          - macos-15
-          - macos-15-intel
-          - ubuntu-latest
-    runs-on: ${{ matrix.os }}
+  ci:
     permissions:
-      artifact-metadata: write
-      attestations: write
-      contents: write
+      contents: read
       id-token: write
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install environment
-        uses: ./.github/workflows/env-install
-
-      - name: Build
-        run: uv run poe build
-
-      - uses: actions/attest@v4
-        with:
-          subject-path: "dist/*"
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: terranova-${{ matrix.os }}
-          path: "dist/*"
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 🧑‍💻 What is the change being made?

- Add artifact attestation and upload steps to the build job in ci.yml
- Add new sanitize job to verify built binaries across macOS and Linux platforms
- Refactor release workflow to reuse the CI workflow instead of duplicating build steps

## :question: Why is the change being made?

Improve CI/CD reliability by:
- Adding artifact verification to ensure binaries are executable
- Reducing duplication between CI and release workflows
- Ensuring built artifacts are properly attested and preserved

## :white_check_mark: How has this been tested?

- [ ] Verify CI workflow builds artifacts and runs sanitize job
- [ ] Verify release workflow triggers CI and creates release
- [ ] Check that binaries are correctly verified on all platforms (macOS amd64/arm64, Linux amd64/arm64)

## :books: How has this been documented?

CI workflow changes documented in workflow files themselves.

## :link: Related Issues

None